### PR TITLE
Implement GL_LINE_SMOOTH

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -521,6 +521,7 @@ GL_API GLboolean glIsEnabled(GLenum feature) {
     case GL_TEXTURE_GEN_T:        return pbgl.flags.texgen_t;
     case GL_TEXTURE_GEN_R:        return pbgl.flags.texgen_r;
     case GL_TEXTURE_GEN_Q:        return pbgl.flags.texgen_q;
+    case GL_LINE_SMOOTH:          return pbgl.flags.line_smooth;
     default:
       pbgl_set_error(GL_INVALID_ENUM);
       return GL_FALSE;

--- a/src/state.c
+++ b/src/state.c
@@ -136,6 +136,8 @@ void pbgl_state_init(void) {
   // TODO:
   pbgl.scissor.dirty = GL_TRUE;
 
+  pbgl.line.dirty = GL_TRUE;
+
   pbgl.clear_zstencil = 0xFFFFFF00; // TODO: this assumes 24-bit z + 8-bit stencil
 
   pbgl.state_dirty = GL_TRUE;
@@ -191,6 +193,11 @@ GLboolean pbgl_state_flush(void) {
   if (!pbgl.state_dirty) return GL_FALSE;
 
   GLuint *p = pb_begin();
+
+  if (pbgl.line.dirty) {
+    p = push_command_boolean(p, NV20_TCL_PRIMITIVE_3D_LINE_SMOOTH_ENABLE, pbgl.flags.line_smooth);
+    pbgl.line.dirty = GL_FALSE;
+  }
 
   if (pbgl.alpha.dirty) {
     // alpha kill might have changed
@@ -444,6 +451,12 @@ static inline void set_feature(GLenum feature, GLboolean value) {
       break;
     case GL_TEXTURE_GEN_Q:
       pbgl.flags.texgen_q = value;
+      break;
+    case GL_LINE_SMOOTH:
+      if (pbgl.flags.line_smooth != value) {
+          pbgl.flags.line_smooth = value;
+          pbgl.line.dirty = GL_TRUE;
+      }
       break;
     default:
       pbgl_set_error(GL_INVALID_ENUM);

--- a/src/state.h
+++ b/src/state.h
@@ -26,6 +26,7 @@ typedef union {
     GLuint texgen_s     : 1; // 12
     GLuint texgen_t     : 1; // 13
     GLuint normalize    : 1; // 14
+    GLuint line_smooth  : 1; // 15
   };
   GLuint word;
 } server_flags_t;
@@ -166,6 +167,10 @@ typedef struct {
 
 typedef struct {
   GLboolean dirty;
+} line_state_t;
+
+typedef struct {
+  GLboolean dirty;
   GLint x;
   GLint y;
   GLint w;
@@ -219,6 +224,7 @@ typedef struct {
   cull_state_t cullface;
   light_model_state_t lightmodel;
   fog_state_t fog;
+  line_state_t line;
 
   immediate_state_t imm;
   varray_state_t varray[VARR_COUNT];


### PR DESCRIPTION
Hey there! 

A relatively simple change, to introduce GL_LINE_SMOOTH which is used in Gish (and my original xbox port of Gish.)

Note: There doesn't seem to be a NV097 equivalent define in nxdk for `LINE_SMOOTH_ENABLE`, but I noticed a large overlap between NV20 and NV097 commands, so hopefully this isn't a problem. (I certainly haven't encountered any.) 

Disabled:
![LINE_SMOOTH disabled](https://user-images.githubusercontent.com/97147377/184182314-84090a6a-9c3d-4c4e-bbcc-fe02aadb869c.png)
Enabled:
![LINE_SMOOTH enabled](https://user-images.githubusercontent.com/97147377/184182320-2cb6e22b-91ee-4b42-a52a-650a3804bab3.png)

Cheers
