### PR TITLE
Implement glPolygonMode

### DIFF
--- a/src/state.h
+++ b/src/state.h
@@ -65,6 +65,12 @@ typedef struct {
 
 typedef struct {
   GLboolean dirty;
+  GLuint front_mode;
+  GLuint back_mode;
+} poly_mode_state_t;
+
+typedef struct {
+  GLboolean dirty;
   GLenum func;
   GLubyte ref;
 } alpha_state_t;
@@ -215,6 +221,7 @@ typedef struct {
   depth_state_t depth;
   stencil_state_t stencil;
   polyofs_state_t polyofs;
+  poly_mode_state_t polymode;
   color_mask_t colormask;
   cull_state_t cullface;
   light_model_state_t lightmodel;


### PR DESCRIPTION
Hello!

I've implemented glPolygonMode for debugging purposes (in my case at least!) 

Note: XEmu does not like when the front and back mode differ. I can test this on my original xbox if needed.

Linux (OpenGL):
Fill:
![linux_gl_fill](https://user-images.githubusercontent.com/97147377/184193164-c0ad041e-4576-422c-ba46-0fc7c75cb0b6.png)
Line:
![linux_gl_line](https://user-images.githubusercontent.com/97147377/184193183-dfabfb6b-bf07-4806-a108-67dbfa3e12b0.png)
Point:
![linux_gl_point](https://user-images.githubusercontent.com/97147377/184193202-667a89e4-8632-4c6e-a374-aa6403720781.png)

Xbox:
Fill:
![xbox_gl_fill](https://user-images.githubusercontent.com/97147377/184193231-7237c154-4760-4fe3-8964-9cbf616b2999.png)
Line:
![xbox_gl_line](https://user-images.githubusercontent.com/97147377/184193262-e313be36-c0e3-434d-a56e-03de807970c4.png)
Point:
![xbox_gl_point](https://user-images.githubusercontent.com/97147377/184193274-e37318bc-7314-453b-8dd8-07322f8d06df.png)

Any differences are probably resolution based. 

Cheers