### PR TITLE
[Build] add CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.16)
+project(pbgl LANGUAGES C)
+
+set(PBGL_VERSION 0.1)
+set(PBGL_GL_VERSION 1.2)
+
+add_library(pbgl
+  src/array.c
+  src/error.c
+  src/fog.c
+  src/immediate.c
+  src/info.c
+  src/light.c
+  src/matrix.c
+  src/memory.c
+  src/misc.c
+  src/pbgl.c
+  src/state.c
+  src/swizzle.c
+  src/texenv.c
+  src/texgen.c
+  src/texture.c
+  src/types.c
+)
+
+add_definitions(
+  -DXBOX
+  -DPBGL_VERSION=0.1
+  -DPBGL_GL_VERSION=1.2
+)
+
+target_include_directories(pbgl PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)


### PR DESCRIPTION
Hi! I have my own fork only to add CMakeLists.txt. It would be nice if this could be part of official repo. This allows me to easily integrate PBGL inside Kodi/XBMC port using NXDK.

 https://github.com/antonic901/xbmc4xbox-nxdk/commit/49192a5ec79e512efa12276df35c67a5b4652ddb